### PR TITLE
Feat: pass lists of obstacles and radius_obstacles to compute_action()

### DIFF
--- a/fabrics/helpers/casadiFunctionWrapper.py
+++ b/fabrics/helpers/casadiFunctionWrapper.py
@@ -24,7 +24,17 @@ class CasadiFunctionWrapper(object):
         for key in kwargs:
             assert isinstance(kwargs[key], np.ndarray)
         try:
-            input_arrays = [kwargs[i] for i in self._input_keys]
+            temp_dic = {}
+            for i in kwargs:
+                if i == "x_obst":
+                    for j in range(len(kwargs[i])):
+                       temp_dic[f"x_obst_{j}"] = kwargs[i][j]
+                if i == "radius_obst":
+                    for j in range(len(kwargs[i])):
+                       temp_dic[f"radius_obst_{j}"] = kwargs[i][j]
+                temp_dic[i]=kwargs[i]
+
+            input_arrays = [temp_dic[i] for i in self._input_keys]
         except KeyError as e:
             msg = f"Key {e} is not contained in the inputs\n"
             msg += f"Possible keys are {self._input_keys}\n"


### PR DESCRIPTION
Allow a list of `x_obst` and `radius_obst` to be passed to `evaluate()` instead of passing elements one by one.

It's a quick workaround without touching other parts of `fabrics`.