### PR TITLE
Option for specifying path for autogenerated c-code

### DIFF
--- a/fabrics/planner/parameterized_planner.py
+++ b/fabrics/planner/parameterized_planner.py
@@ -1,6 +1,7 @@
 import logging
 from copy import deepcopy
 from typing import Dict, List, Optional
+import os
 
 import casadi as ca
 import deprecation
@@ -755,13 +756,17 @@ class ParameterizedFabricPlanner(object):
         function.save(file_name)
 
 
-    def export_as_c(self, file_name: str, file_path:str = ""):
+    def export_as_c(self, file_name: str):
         """
         Export the planner as c source code.
         """
-        gen = ca.CodeGenerator(file_name)
+        filepath, filename = os.path.split(file_name)
+        if not filepath.endswith(os.sep):
+            filepath += os.sep
+        
+        gen = ca.CodeGenerator(filename)
         gen.add(self._funs.function())
-        gen.generate(file_path)
+        gen.generate(filepath)
 
  
     """ RUNTIME METHODS """

--- a/fabrics/planner/parameterized_planner.py
+++ b/fabrics/planner/parameterized_planner.py
@@ -754,12 +754,15 @@ class ParameterizedFabricPlanner(object):
         function = self._funs.function()
         function.save(file_name)
 
-    def export_as_c(self, file_name: str):
+
+    def export_as_c(self, file_name: str, file_path:str = ""):
         """
         Export the planner as c source code.
         """
-        function = self._funs.function()
-        function.generate(file_name)
+        gen = ca.CodeGenerator(file_name)
+        gen.add(self._funs.function())
+        gen.generate(file_path)
+
  
     """ RUNTIME METHODS """
 


### PR DESCRIPTION
I modified the `export_as_c` method so that a user has the option to specify the path destination for the generated C code.